### PR TITLE
Fix error in requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Django==5.1.6
 python-dotenv==1.0.1
 dj-database-url==2.3.0
-djangorestframework-3.15.2
+djangorestframework==3.15.2
 daphne==4.1.2
 httpx==0.28.1
 bs4==0.0.2


### PR DESCRIPTION
When running `pip install -r requirements.txt`, we get this error:
![image](https://github.com/user-attachments/assets/5fa6a113-79ee-4d6a-93ca-d70888cbe5fc)

It's happening due to a missing `==` in requirements.txt. This PR fixes that!